### PR TITLE
Lights on puzzles

### DIFF
--- a/MagicTile/MainForm.cs
+++ b/MagicTile/MainForm.cs
@@ -348,7 +348,7 @@
 			double twists = 0, scrambles = 0, total = 0;
 			if( m_puzzle != null && m_puzzle.TwistHistory != null )
 			{
-				total = m_puzzle.TwistHistory.AllTwists.Count();
+				total = m_puzzle.TwistHistory.AllMovesCount;
 				scrambles = m_puzzle.TwistHistory.Scrambles;
 				twists = total - scrambles;
 			}

--- a/MagicTile/Puzzle/Cell.cs
+++ b/MagicTile/Puzzle/Cell.cs
@@ -15,7 +15,7 @@
 			Isometry = new Isometry();
 			IndexOfMaster = -1;
 			PickInfo = new PickInfo[] { };
-            Neighbors = new HashSet<Cell>();
+			Neighbors = new HashSet<Cell>();
 		}
 
 		/// <summary>
@@ -62,15 +62,15 @@
 		/// </summary>
 		public bool IsSlave { get { return Master != null; } }
 
-        /// <summary>
-        /// Return the master cell of this cell, if this is a master itself, return itself
-        /// </summary>
-        public Cell MasterOrSelf { get { return Master ?? this; } }
-        
-        /// <summary>
-        /// List of master cells that share boundary with this cell. If a master cell borders a slave cell, the master of the slave cell is in this list
-        /// </summary>
-        public HashSet<Cell> Neighbors { get; set; }
+		/// <summary>
+		/// Return the master cell of this cell, if this is a master itself, return itself
+		/// </summary>
+		public Cell MasterOrSelf { get { return Master ?? this; } }
+
+		/// <summary>
+		/// List of master cells that share boundary with this cell. If a master cell borders a slave cell, the master of the slave cell is in this list
+		/// </summary>
+		public HashSet<Cell> Neighbors { get; set; }
 
 		/// <summary>
 		/// This is the isometry that will take us back to the master cell.

--- a/MagicTile/Puzzle/Cell.cs
+++ b/MagicTile/Puzzle/Cell.cs
@@ -15,6 +15,7 @@
 			Isometry = new Isometry();
 			IndexOfMaster = -1;
 			PickInfo = new PickInfo[] { };
+            Neighbors = new HashSet<Cell>();
 		}
 
 		/// <summary>
@@ -60,6 +61,11 @@
 		/// Whether or not we are a slave.
 		/// </summary>
 		public bool IsSlave { get { return Master != null; } }
+
+        /// <summary>
+        /// List of master cells that share boundary with this cell. If a master cell borders a slave cell, the master of the slave cell is in this list
+        /// </summary>
+        public HashSet<Cell> Neighbors { get; set; }
 
 		/// <summary>
 		/// This is the isometry that will take us back to the master cell.

--- a/MagicTile/Puzzle/Cell.cs
+++ b/MagicTile/Puzzle/Cell.cs
@@ -63,6 +63,11 @@
 		public bool IsSlave { get { return Master != null; } }
 
         /// <summary>
+        /// Return the master cell of this cell, if this is a master itself, return itself
+        /// </summary>
+        public Cell MasterOrSelf { get { return Master ?? this; } }
+        
+        /// <summary>
         /// List of master cells that share boundary with this cell. If a master cell borders a slave cell, the master of the slave cell is in this list
         /// </summary>
         public HashSet<Cell> Neighbors { get; set; }

--- a/MagicTile/Puzzle/Cell.cs
+++ b/MagicTile/Puzzle/Cell.cs
@@ -68,7 +68,9 @@
 		public Cell MasterOrSelf { get { return Master ?? this; } }
 
 		/// <summary>
-		/// List of master cells that share boundary with this cell. If a master cell borders a slave cell, the master of the slave cell is in this list
+		/// List of master cells that share boundaries with this cell. 
+		/// If a master cell borders a slave cell, the master of the slave cell is in this list.
+		/// A master cell is its own neighbor by definition
 		/// </summary>
 		public HashSet<Cell> Neighbors { get; set; }
 

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -277,7 +277,7 @@
 
 			//TraceGraph();
 
-			if (tStickers.Count == 1)
+			if (Config.TogglingMode != TogglingMode.None)
 			{
 				StatusOrCancel(callback, "populating neighbors...");
 				PopulateNeighbors();

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -230,9 +230,6 @@
 			}
 			callback.Status("Number of completed cells:" + completed.Count);
 
-			StatusOrCancel(callback, "populating neighbors...");
-			PopulateNeighbors();
-
 			StatusOrCancel( callback, "analyzing topology..." );
 			TopologyAnalyzer topology = new TopologyAnalyzer( this, template );
 			topology.Analyze();
@@ -281,6 +278,12 @@
 
 			//TraceGraph();
 
+			if (tStickers.Count == 1)
+			{
+				StatusOrCancel(callback, "populating neighbors...");
+				PopulateNeighbors();
+			}
+
 			this.State = new State( this.MasterCells.Count, tStickers.Count );
 			this.TwistHistory = new TwistHistory();
 
@@ -292,7 +295,6 @@
 			callback.Status( "Number of colors:" + this.MasterCells.Count );
 			callback.Status( "Number of tiles:" + tiling.Tiles.Count() );
 			callback.Status( "Number of cells:" + count );
-			callback.Status( "Number of completed cells:" + completed.Count);
 			callback.Status( "Number of stickers per cell:" + tStickers.Count );
 		}
 
@@ -790,7 +792,6 @@
 						neighbor.MasterOrSelf.Neighbors.Add(master);
 					}
 				}
-				Console.WriteLine($"Master cell {master.IndexOfMaster} neighbor count: {master.Neighbors.Count}");
 			}
 		}
 
@@ -926,7 +927,6 @@
 			// This has to be recalculated, because it may not be the same as the tiling isometries.
 			//cell.Isometry = t.Isometry;
 			cell.Isometry.CalculateFromTwoPolygons( home, boundary, this.Config.Geometry );
-
 			completed[boundary.Center] = cell;
 			return cell;
 		}

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -277,7 +277,7 @@
 
 			//TraceGraph();
 
-			if (Config.TogglingMode != TogglingMode.None)
+			if (Config.IsToggling)
 			{
 				StatusOrCancel(callback, "populating neighbors...");
 				PopulateNeighbors();
@@ -801,6 +801,9 @@
 			return result;
 		}
 
+		/// <summary>
+		/// Populate Neighbors of master cells. A neighbor shares a common edge with a cell. By definition, a cell is its own neighbor
+		/// </summary>
 		private void PopulateNeighbors()
 		{
 			foreach (var master in m_masters)
@@ -951,6 +954,7 @@
 			// This has to be recalculated, because it may not be the same as the tiling isometries.
 			//cell.Isometry = t.Isometry;
 			cell.Isometry.CalculateFromTwoPolygons( home, boundary, this.Config.Geometry );
+
 			completed[boundary.Center] = cell;
 			return cell;
 		}
@@ -2072,6 +2076,11 @@
 		{
 			UpdateState( Config, State, twist );
 		}
+
+		/// <summary>
+		/// Check if puzzle is solved for both normal and toggling modes
+		/// </summary>
+		public bool IsSolved => (Config.IsToggling ? State.IsAllOn : State.IsSolved);
 
 		/// <summary>
 		/// Update the state based on a twist.

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -229,6 +229,7 @@
 				AddMaster( t, tiling, identifications, completed );
 			}
 
+            StatusOrCancel(callback, "populating neighbors...");
             PopulateNeighbors();
 
             StatusOrCancel( callback, "analyzing topology..." );
@@ -897,8 +898,8 @@
 
 		private void AddSlave( Cell master, Cell slave )
 		{
-			// Go ahead and set this.
-			slave.Master = master;
+            // Go ahead and set this.
+            slave.Master = master;
 			slave.IndexOfMaster = master.IndexOfMaster;
 
 			List<Cell> slaves;

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -229,7 +229,9 @@
 				AddMaster( t, tiling, identifications, completed );
 			}
 
-			StatusOrCancel( callback, "analyzing topology..." );
+            PopulateNeighbors();
+
+            StatusOrCancel( callback, "analyzing topology..." );
 			TopologyAnalyzer topology = new TopologyAnalyzer( this, template );
 			topology.Analyze();
 			this.Topology = topology.ToString();
@@ -291,7 +293,7 @@
 			callback.Status( "Number of stickers per cell:" + tStickers.Count );
 		}
 
-		private IEnumerable<Tile> MasterCandidates( Tiling tiling )
+        private IEnumerable<Tile> MasterCandidates( Tiling tiling )
 		{
 			IEnumerable<Tile> masterCandidates = tiling.Tiles;
 
@@ -769,8 +771,28 @@
 
 			return result;
 		}
+        
+        private void PopulateNeighbors()
+        {
+            foreach (var master in m_masters)
+            {
+                foreach (var cell in AllCells)
+                {
+                    var hasCommonEdge = master.Boundary.EdgeMidpoints
+                        .Any(masterEdgeMidPoint => cell.Boundary.EdgeMidpoints
+                            .Any(cellEdgeMidPoint => masterEdgeMidPoint == cellEdgeMidPoint));
+                    if (hasCommonEdge)
+                    {
+                        var neighborMaster = cell.IsMaster ? cell : cell.Master;
+                        master.Neighbors.Add(neighborMaster);
+                        neighborMaster.Neighbors.Add(master);
+                    }
+                }
+                Console.WriteLine($"neighbor count: {master.Neighbors.Count}");
+            }
+        }
 
-		private void AddMaster( Tile tile, Tiling tiling, PuzzleIdentifications identifications, Dictionary<Vector3D, Cell> completed )
+        private void AddMaster( Tile tile, Tiling tiling, PuzzleIdentifications identifications, Dictionary<Vector3D, Cell> completed )
 		{
 			Cell master = SetupCell( tiling.Tiles.First(), tile.Boundary, completed );
 			master.IndexOfMaster = m_masters.Count;

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -1304,8 +1304,6 @@
 			// Now build the near tree.
 			foreach( KeyValuePair<Vector3D, Cell> keyValuePair in cellMap )
 			{
-				// Ignore the orphaned cells in cellMap. They are not reachable from the masters list
-				if(keyValuePair.Value.IndexOfMaster == -1) continue;
 				// NearTree doesn't like NaN or +Inf
 				Vector3D center = InfinitySafe( keyValuePair.Key );
 

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -228,12 +228,12 @@
 				// Add it (this will add all the slaves too).
 				AddMaster( t, tiling, identifications, completed );
 			}
-            callback.Status("Number of completed cells:" + completed.Count);
+			callback.Status("Number of completed cells:" + completed.Count);
 
-            StatusOrCancel(callback, "populating neighbors...");
-            PopulateNeighbors();
+			StatusOrCancel(callback, "populating neighbors...");
+			PopulateNeighbors();
 
-            StatusOrCancel( callback, "analyzing topology..." );
+			StatusOrCancel( callback, "analyzing topology..." );
 			TopologyAnalyzer topology = new TopologyAnalyzer( this, template );
 			topology.Analyze();
 			this.Topology = topology.ToString();
@@ -292,11 +292,11 @@
 			callback.Status( "Number of colors:" + this.MasterCells.Count );
 			callback.Status( "Number of tiles:" + tiling.Tiles.Count() );
 			callback.Status( "Number of cells:" + count );
-            callback.Status( "Number of completed cells:" + completed.Count);
-            callback.Status( "Number of stickers per cell:" + tStickers.Count );
+			callback.Status( "Number of completed cells:" + completed.Count);
+			callback.Status( "Number of stickers per cell:" + tStickers.Count );
 		}
 
-        private IEnumerable<Tile> MasterCandidates( Tiling tiling )
+		private IEnumerable<Tile> MasterCandidates( Tiling tiling )
 		{
 			IEnumerable<Tile> masterCandidates = tiling.Tiles;
 
@@ -774,27 +774,27 @@
 
 			return result;
 		}
-        
-        private void PopulateNeighbors()
-        {
-            foreach (var master in m_masters)
-            {
-                foreach (var neighbor in AllCells)
-                {
-                    var hasCommonEdge = master.Boundary.EdgeMidpoints
-                        .Any(masterEdgeMidPoint => neighbor.Boundary.EdgeMidpoints
-                            .Any(cellEdgeMidPoint => masterEdgeMidPoint == cellEdgeMidPoint));
-                    if (hasCommonEdge)
-                    {
-                        master.Neighbors.Add(neighbor.MasterOrSelf);
-                        neighbor.MasterOrSelf.Neighbors.Add(master);
-                    }
-                }
-                Console.WriteLine($"Master cell {master.IndexOfMaster} neighbor count: {master.Neighbors.Count}");
-            }
-        }
 
-        private void AddMaster( Tile tile, Tiling tiling, PuzzleIdentifications identifications, Dictionary<Vector3D, Cell> completed )
+		private void PopulateNeighbors()
+		{
+			foreach (var master in m_masters)
+			{
+				foreach (var neighbor in AllCells)
+				{
+					var hasCommonEdge = master.Boundary.EdgeMidpoints
+						.Any(masterEdgeMidPoint => neighbor.Boundary.EdgeMidpoints
+							.Any(cellEdgeMidPoint => masterEdgeMidPoint == cellEdgeMidPoint));
+					if (hasCommonEdge)
+					{
+						master.Neighbors.Add(neighbor.MasterOrSelf);
+						neighbor.MasterOrSelf.Neighbors.Add(master);
+					}
+				}
+				Console.WriteLine($"Master cell {master.IndexOfMaster} neighbor count: {master.Neighbors.Count}");
+			}
+		}
+
+		private void AddMaster( Tile tile, Tiling tiling, PuzzleIdentifications identifications, Dictionary<Vector3D, Cell> completed )
 		{
 			Cell master = SetupCell( tiling.Tiles.First(), tile.Boundary, completed );
 			master.IndexOfMaster = m_masters.Count;

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -228,6 +228,7 @@
 				// Add it (this will add all the slaves too).
 				AddMaster( t, tiling, identifications, completed );
 			}
+            callback.Status("Number of completed cells:" + completed.Count);
 
             StatusOrCancel(callback, "populating neighbors...");
             PopulateNeighbors();
@@ -291,7 +292,8 @@
 			callback.Status( "Number of colors:" + this.MasterCells.Count );
 			callback.Status( "Number of tiles:" + tiling.Tiles.Count() );
 			callback.Status( "Number of cells:" + count );
-			callback.Status( "Number of stickers per cell:" + tStickers.Count );
+            callback.Status( "Number of completed cells:" + completed.Count);
+            callback.Status( "Number of stickers per cell:" + tStickers.Count );
 		}
 
         private IEnumerable<Tile> MasterCandidates( Tiling tiling )
@@ -898,8 +900,8 @@
 
 		private void AddSlave( Cell master, Cell slave )
 		{
-            // Go ahead and set this.
-            slave.Master = master;
+			// Go ahead and set this.
+			slave.Master = master;
 			slave.IndexOfMaster = master.IndexOfMaster;
 
 			List<Cell> slaves;

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -776,19 +776,18 @@
         {
             foreach (var master in m_masters)
             {
-                foreach (var cell in AllCells)
+                foreach (var neighbor in AllCells)
                 {
                     var hasCommonEdge = master.Boundary.EdgeMidpoints
-                        .Any(masterEdgeMidPoint => cell.Boundary.EdgeMidpoints
+                        .Any(masterEdgeMidPoint => neighbor.Boundary.EdgeMidpoints
                             .Any(cellEdgeMidPoint => masterEdgeMidPoint == cellEdgeMidPoint));
                     if (hasCommonEdge)
                     {
-                        var neighborMaster = cell.IsMaster ? cell : cell.Master;
-                        master.Neighbors.Add(neighborMaster);
-                        neighborMaster.Neighbors.Add(master);
+                        master.Neighbors.Add(neighbor.MasterOrSelf);
+                        neighbor.MasterOrSelf.Neighbors.Add(master);
                     }
                 }
-                Console.WriteLine($"neighbor count: {master.Neighbors.Count}");
+                Console.WriteLine($"Master cell {master.IndexOfMaster} neighbor count: {master.Neighbors.Count}");
             }
         }
 

--- a/MagicTile/Puzzle/Puzzle.cs
+++ b/MagicTile/Puzzle/Puzzle.cs
@@ -228,7 +228,6 @@
 				// Add it (this will add all the slaves too).
 				AddMaster( t, tiling, identifications, completed );
 			}
-			callback.Status("Number of completed cells:" + completed.Count);
 
 			StatusOrCancel( callback, "analyzing topology..." );
 			TopologyAnalyzer topology = new TopologyAnalyzer( this, template );
@@ -1305,6 +1304,8 @@
 			// Now build the near tree.
 			foreach( KeyValuePair<Vector3D, Cell> keyValuePair in cellMap )
 			{
+				// Ignore the orphaned cells in cellMap. They are not reachable from the masters list
+				if(keyValuePair.Value.IndexOfMaster == -1) continue;
 				// NearTree doesn't like NaN or +Inf
 				Vector3D center = InfinitySafe( keyValuePair.Key );
 

--- a/MagicTile/Puzzle/PuzzleConfig.cs
+++ b/MagicTile/Puzzle/PuzzleConfig.cs
@@ -431,7 +431,6 @@
 
 	public enum TogglingMode
 	{
-		None,
 		NeighborsOnly,
 		NeighborsAndSelf
 	}
@@ -512,9 +511,14 @@
 		public bool CoxeterComplex { get; set; }
 
 		/// <summary>
-		/// Flag to indicate we are in the toggling mode.
+		/// Flag to indicate if the puzzle is in toggling mode (light on puzzle)
 		/// </summary>
-		public TogglingMode TogglingMode { get; set; }
+		public bool IsToggling => (TogglingMode != null);
+
+		/// <summary>
+		/// Toggling mode. Null means a normal puzzle (not toggling)
+		/// </summary>
+		public TogglingMode? TogglingMode { get; set; }
 
 		/// <summary>
 		/// The number of sides in a polygonal face.

--- a/MagicTile/Puzzle/PuzzleConfig.cs
+++ b/MagicTile/Puzzle/PuzzleConfig.cs
@@ -505,6 +505,11 @@
 		public bool CoxeterComplex { get; set; }
 
 		/// <summary>
+		/// Flag to indicate we are in the toggling mode.
+		/// </summary>
+		public bool TogglingMode { get; set; }
+
+		/// <summary>
 		/// The number of sides in a polygonal face.
 		/// </summary>
 		[DataMember]

--- a/MagicTile/Puzzle/PuzzleConfig.cs
+++ b/MagicTile/Puzzle/PuzzleConfig.cs
@@ -429,6 +429,13 @@
 		Bitruncated5Cell,
 	}
 
+	public enum TogglingMode
+	{
+		None,
+		NeighborsOnly,
+		NeighborsAndSelf
+	}
+
 	/// <summary>
 	/// Configuration required for generating regular 4D skew polyedra data associate with the puzzle.
 	/// </summary>
@@ -507,7 +514,7 @@
 		/// <summary>
 		/// Flag to indicate we are in the toggling mode.
 		/// </summary>
-		public bool TogglingMode { get; set; }
+		public TogglingMode TogglingMode { get; set; }
 
 		/// <summary>
 		/// The number of sides in a polygonal face.

--- a/MagicTile/Puzzle/PuzzleConfigClass.cs
+++ b/MagicTile/Puzzle/PuzzleConfigClass.cs
@@ -223,7 +223,7 @@
 			for (var i = 0; i < 2; i++)
 			{
 				toggles[i] = NonSpecific();
-				toggles[i].MenuName = (i == 0 ? "Toggle Neighbors Only" : "Toggle Clicked Cell And Neighbors");
+				toggles[i].MenuName = (i == 0 ? "Toggling Neighbors" : "Toggling Clicked Tile And Neighbors");
 				toggles[i].TogglingMode = (i == 0 ? TogglingMode.NeighborsOnly : TogglingMode.NeighborsAndSelf);
 				toggles[i].DisplayName = ClassDisplayName + " " + toggles[i].MenuName;
 			}

--- a/MagicTile/Puzzle/PuzzleConfigClass.cs
+++ b/MagicTile/Puzzle/PuzzleConfigClass.cs
@@ -205,12 +205,11 @@
 		/// All the puzzles we represent.
 		/// </summary>
 		public void GetPuzzles( out PuzzleConfig[] tilings, out PuzzleConfig[] face, out PuzzleConfig[] edge, 
-			out PuzzleConfig[] vertex, out PuzzleConfig[] mixed, out PuzzleConfig[] earthquake )
+			out PuzzleConfig[] vertex, out PuzzleConfig[] mixed, out PuzzleConfig[] earthquake, out PuzzleConfig[] toggles )
 		{
 			PuzzleConfig tiling = NonSpecific();
 			tiling.MenuName = "Tiling";
 			tiling.DisplayName = this.ClassDisplayName + " " + tiling.MenuName;
-			tiling.TogglingMode = true;
 
 			PuzzleConfig coxeter = NonSpecific();
 			coxeter.CoxeterComplex = true;
@@ -219,6 +218,15 @@
 			coxeter.SlicingCircles.Thickness = 0.01;
 
 			tilings = new PuzzleConfig[] { tiling, coxeter };
+
+			toggles = new PuzzleConfig[2];
+			for (var i = 0; i < 2; i++)
+			{
+				toggles[i] = NonSpecific();
+				toggles[i].MenuName = (i == 0 ? "Toggle Neighbors Only" : "Toggle Clicked Cell And Neighbors");
+				toggles[i].TogglingMode = (i == 0 ? TogglingMode.NeighborsOnly : TogglingMode.NeighborsAndSelf);
+				toggles[i].DisplayName = ClassDisplayName + " " + toggles[i].MenuName;
+			}
 
 			List<PuzzleConfig> puzzles = new List<PuzzleConfig>();
 			foreach( PuzzleSpecific puzzleSpecific in this.PuzzleSpecificList )

--- a/MagicTile/Puzzle/PuzzleConfigClass.cs
+++ b/MagicTile/Puzzle/PuzzleConfigClass.cs
@@ -210,6 +210,7 @@
 			PuzzleConfig tiling = NonSpecific();
 			tiling.MenuName = "Tiling";
 			tiling.DisplayName = this.ClassDisplayName + " " + tiling.MenuName;
+			tiling.TogglingMode = true;
 
 			PuzzleConfig coxeter = NonSpecific();
 			coxeter.CoxeterComplex = true;

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1716,13 +1716,7 @@
 			Cell closest = FindClosestCell(clickData.X, clickData.Y, out spaceCoordsNoMouseMotion);
 			if (closest == null || !spaceCoordsNoMouseMotion.HasValue)
 				return;
-
-			Cell closestMaster = closest.MasterOrSelf;
-			foreach (Cell neighbor in closestMaster.Neighbors)
-			{
-				m_puzzle.State.ToggleStickerColorIndex(neighbor.IndexOfMaster, 0);
-			}
-			m_puzzle.State.CommitChanges();
+			this.TwistHandler.Toggle(closest);
 			Render(true);
 		}
 

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1684,35 +1684,35 @@ namespace MagicTile
 			m_glControl.Invalidate();
 		}
 
-	    private void PerformLightsOutClick(ClickData clickData)
-	    {
-            Vector3D? spaceCoordsNoMouseMotion;
-            Cell closest = FindClosestCell(clickData.X, clickData.Y, out spaceCoordsNoMouseMotion);
-            if (closest == null || !spaceCoordsNoMouseMotion.HasValue)
-                return;
+		private void PerformLightsOutClick(ClickData clickData)
+		{
+			Vector3D? spaceCoordsNoMouseMotion;
+			Cell closest = FindClosestCell(clickData.X, clickData.Y, out spaceCoordsNoMouseMotion);
+			if (closest == null || !spaceCoordsNoMouseMotion.HasValue)
+				return;
 
-            var closestMaster = closest.MasterOrSelf;
-            Console.WriteLine(String.Join(";", m_puzzle.MasterCells.Select(c => c.IndexOfMaster)));
-            Console.WriteLine(closest.IsMaster);
-            Console.WriteLine(closestMaster.IndexOfMaster);
-            Console.WriteLine(closest.IndexOfMaster);
-            Console.WriteLine(m_puzzle.MasterCells.IndexOf(closest));
-            Console.WriteLine(m_puzzle.AllCells.ToList().IndexOf(closest));
+			var closestMaster = closest.MasterOrSelf;
+			Console.WriteLine(String.Join(";", m_puzzle.MasterCells.Select(c => c.IndexOfMaster)));
+			Console.WriteLine(closest.IsMaster);
+			Console.WriteLine(closestMaster.IndexOfMaster);
+			Console.WriteLine(closest.IndexOfMaster);
+			Console.WriteLine(m_puzzle.MasterCells.IndexOf(closest));
+			Console.WriteLine(m_puzzle.AllCells.ToList().IndexOf(closest));
 
-            var color = m_puzzle.State.GetStickerColor(closestMaster.IndexOfMaster, 0);
+			var color = m_puzzle.State.GetStickerColor(closestMaster.IndexOfMaster, 0);
 
-            // TODO: toggle color
-            Console.WriteLine($"Before click: Master index of the closest cell is: {closestMaster.IndexOfMaster}, color is {color.Name}");
-            m_puzzle.State.ToggleStickerColorIndex(closestMaster.IndexOfMaster, 0);
-            m_puzzle.State.CommitChanges();
-            var afterColor = m_puzzle.State.GetStickerColor(closestMaster.IndexOfMaster, 0);
+			// TODO: toggle color
+			Console.WriteLine($"Before click: Master index of the closest cell is: {closestMaster.IndexOfMaster}, color is {color.Name}");
+			m_puzzle.State.ToggleStickerColorIndex(closestMaster.IndexOfMaster, 0);
+			m_puzzle.State.CommitChanges();
+			var afterColor = m_puzzle.State.GetStickerColor(closestMaster.IndexOfMaster, 0);
 
-            // TODO: toggle color
-            Console.WriteLine($"After click: Master index of the closest cell is: {closestMaster.IndexOfMaster}, color is {afterColor.Name}");
-            Render();
-        }
+			// TODO: toggle color
+			Console.WriteLine($"After click: Master index of the closest cell is: {closestMaster.IndexOfMaster}, color is {afterColor.Name}");
+			Render();
+		}
 
-        private void PerformClick( ClickData clickData )
+		private void PerformClick( ClickData clickData )
 		{
 			// Handle macros.
 			if( AltDown )
@@ -1772,11 +1772,11 @@ namespace MagicTile
 				FindClosestTwistingCircles( clickData.X, clickData.Y );
 			}
 
-		    if (m_closestTwistingCircles == null)
-		    {
-                PerformLightsOutClick(clickData);
-                return;
-		    }
+			if (m_closestTwistingCircles == null)
+			{
+				PerformLightsOutClick(clickData);
+				return;
+			}
 
 			SingleTwist twist = new SingleTwist();
 			twist.IdentifiedTwistData = m_closestTwistingCircles.IdentifiedTwistData;

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1780,7 +1780,7 @@
 				FindClosestTwistingCircles( clickData.X, clickData.Y );
 			}
 
-			if( m_puzzle.Config.TogglingMode )
+			if( m_puzzle.Config.TogglingMode != TogglingMode.None )
 			{
 				PerformTogglingClick(clickData);
 			}

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -167,7 +167,7 @@
 		}
 		public double WaitRadius { get; set; }
 
-		public void Render()
+		public void Render(bool forceUpdateTexture = false)
 		{
 			/* Optimization is pretty tricky.
 			 * 
@@ -194,6 +194,9 @@
 			bool useTexture = !spherical || ShowOnSurface;
 			if( useTexture )
 			{
+				if(forceUpdateTexture)
+					m_renderToTexture.InvalidateAllTextures();
+
 				GenTextures();
 
 				if( this.ShowOnSurface || this.ShowAsSkew )
@@ -1695,7 +1698,7 @@
 				m_puzzle.State.ToggleStickerColorIndex(neighbor.IndexOfMaster, 0);
 			}
 			m_puzzle.State.CommitChanges();
-			Render();
+			Render(true);
 		}
 
 		private void PerformClick( ClickData clickData )

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1682,7 +1682,7 @@
 			m_glControl.Invalidate();
 		}
 
-		private void PerformLightsOutClick(ClickData clickData)
+		private void PerformTogglingClick(ClickData clickData)
 		{
 			Vector3D? spaceCoordsNoMouseMotion;
 			Cell closest = FindClosestCell(clickData.X, clickData.Y, out spaceCoordsNoMouseMotion);
@@ -1760,7 +1760,7 @@
 
 			if( m_closestTwistingCircles == null )
 			{
-				PerformLightsOutClick(clickData);
+				PerformTogglingClick(clickData);
 				return;
 			}
 

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1786,9 +1786,13 @@
 				FindClosestTwistingCircles( clickData.X, clickData.Y );
 			}
 
-			if( m_closestTwistingCircles == null )
+			if( m_puzzle.Config.TogglingMode )
 			{
 				PerformTogglingClick(clickData);
+			}
+
+			if( m_closestTwistingCircles == null )
+			{
 				return;
 			}
 

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1712,6 +1712,13 @@
 
 		private void PerformTogglingClick(ClickData clickData)
 		{
+			if (this.ShowAsSkew)
+			{
+				string message = "Sorry, Lights On moves are not supported on the skew view at this time. To turn off the skew view, go to Settings -> Skew Polyhedra and set \"Show as Skew\" to False";
+				System.Windows.Forms.MessageBox.Show(message, "Unsupported", MessageBoxButtons.OK, MessageBoxIcon.Information);
+				return;
+			}
+
 			Vector3D? spaceCoordsNoMouseMotion;
 			Cell closest = FindClosestCell(clickData.X, clickData.Y, out spaceCoordsNoMouseMotion);
 			if (closest == null || !spaceCoordsNoMouseMotion.HasValue)

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace MagicTile
+﻿namespace MagicTile
 {
 	using MagicTile.Control;
 	using OpenTK.Graphics.OpenGL;
@@ -1691,24 +1689,12 @@ namespace MagicTile
 			if (closest == null || !spaceCoordsNoMouseMotion.HasValue)
 				return;
 
-			var closestMaster = closest.MasterOrSelf;
-			Console.WriteLine(String.Join(";", m_puzzle.MasterCells.Select(c => c.IndexOfMaster)));
-			Console.WriteLine(closest.IsMaster);
-			Console.WriteLine(closestMaster.IndexOfMaster);
-			Console.WriteLine(closest.IndexOfMaster);
-			Console.WriteLine(m_puzzle.MasterCells.IndexOf(closest));
-			Console.WriteLine(m_puzzle.AllCells.ToList().IndexOf(closest));
-
-			var color = m_puzzle.State.GetStickerColor(closestMaster.IndexOfMaster, 0);
-
-			// TODO: toggle color
-			Console.WriteLine($"Before click: Master index of the closest cell is: {closestMaster.IndexOfMaster}, color is {color.Name}");
-			m_puzzle.State.ToggleStickerColorIndex(closestMaster.IndexOfMaster, 0);
+			Cell closestMaster = closest.MasterOrSelf;
+			foreach (Cell neighbor in closestMaster.Neighbors)
+			{
+				m_puzzle.State.ToggleStickerColorIndex(neighbor.IndexOfMaster, 0);
+			}
 			m_puzzle.State.CommitChanges();
-			var afterColor = m_puzzle.State.GetStickerColor(closestMaster.IndexOfMaster, 0);
-
-			// TODO: toggle color
-			Console.WriteLine($"After click: Master index of the closest cell is: {closestMaster.IndexOfMaster}, color is {afterColor.Name}");
 			Render();
 		}
 
@@ -1772,7 +1758,7 @@ namespace MagicTile
 				FindClosestTwistingCircles( clickData.X, clickData.Y );
 			}
 
-			if (m_closestTwistingCircles == null)
+			if( m_closestTwistingCircles == null )
 			{
 				PerformLightsOutClick(clickData);
 				return;

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1787,7 +1787,7 @@
 				FindClosestTwistingCircles( clickData.X, clickData.Y );
 			}
 
-			if( m_puzzle.Config.TogglingMode != TogglingMode.None )
+			if( m_puzzle.Config.IsToggling)
 			{
 				PerformTogglingClick(clickData);
 			}

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1684,7 +1684,35 @@ namespace MagicTile
 			m_glControl.Invalidate();
 		}
 
-		private void PerformClick( ClickData clickData )
+	    private void PerformLightsOutClick(ClickData clickData)
+	    {
+            Vector3D? spaceCoordsNoMouseMotion;
+            Cell closest = FindClosestCell(clickData.X, clickData.Y, out spaceCoordsNoMouseMotion);
+            if (closest == null || !spaceCoordsNoMouseMotion.HasValue)
+                return;
+
+            var closestMaster = closest.MasterOrSelf;
+            Console.WriteLine(String.Join(";", m_puzzle.MasterCells.Select(c => c.IndexOfMaster)));
+            Console.WriteLine(closest.IsMaster);
+            Console.WriteLine(closestMaster.IndexOfMaster);
+            Console.WriteLine(closest.IndexOfMaster);
+            Console.WriteLine(m_puzzle.MasterCells.IndexOf(closest));
+            Console.WriteLine(m_puzzle.AllCells.ToList().IndexOf(closest));
+
+            var color = m_puzzle.State.GetStickerColor(closestMaster.IndexOfMaster, 0);
+
+            // TODO: toggle color
+            Console.WriteLine($"Before click: Master index of the closest cell is: {closestMaster.IndexOfMaster}, color is {color.Name}");
+            m_puzzle.State.ToggleStickerColorIndex(closestMaster.IndexOfMaster, 0);
+            m_puzzle.State.CommitChanges();
+            var afterColor = m_puzzle.State.GetStickerColor(closestMaster.IndexOfMaster, 0);
+
+            // TODO: toggle color
+            Console.WriteLine($"After click: Master index of the closest cell is: {closestMaster.IndexOfMaster}, color is {afterColor.Name}");
+            Render();
+        }
+
+        private void PerformClick( ClickData clickData )
 		{
 			// Handle macros.
 			if( AltDown )
@@ -1746,15 +1774,8 @@ namespace MagicTile
 
 		    if (m_closestTwistingCircles == null)
 		    {
-                Vector3D? spaceCoordsNoMouseMotion;
-                Cell closest = FindClosestCell(clickData.X, clickData.Y, out spaceCoordsNoMouseMotion);
-                if (closest == null || !spaceCoordsNoMouseMotion.HasValue)
-                    return;
-
-                // TODO: toggle color
-                Console.WriteLine($"Master index of the closest cell is: {closest.MasterOrSelf.IndexOfMaster}");
-
-		        return;
+                PerformLightsOutClick(clickData);
+                return;
 		    }
 
 			SingleTwist twist = new SingleTwist();

--- a/MagicTile/Puzzle/PuzzleRenderer.cs
+++ b/MagicTile/Puzzle/PuzzleRenderer.cs
@@ -1,4 +1,6 @@
-﻿namespace MagicTile
+﻿using System;
+
+namespace MagicTile
 {
 	using MagicTile.Control;
 	using OpenTK.Graphics.OpenGL;
@@ -1742,8 +1744,18 @@
 				FindClosestTwistingCircles( clickData.X, clickData.Y );
 			}
 
-			if( m_closestTwistingCircles == null )
-				return;
+		    if (m_closestTwistingCircles == null)
+		    {
+                Vector3D? spaceCoordsNoMouseMotion;
+                Cell closest = FindClosestCell(clickData.X, clickData.Y, out spaceCoordsNoMouseMotion);
+                if (closest == null || !spaceCoordsNoMouseMotion.HasValue)
+                    return;
+
+                // TODO: toggle color
+                Console.WriteLine($"Master index of the closest cell is: {closest.MasterOrSelf.IndexOfMaster}");
+
+		        return;
+		    }
 
 			SingleTwist twist = new SingleTwist();
 			twist.IdentifiedTwistData = m_closestTwistingCircles.IdentifiedTwistData;

--- a/MagicTile/Puzzle/State.cs
+++ b/MagicTile/Puzzle/State.cs
@@ -12,8 +12,8 @@
 		{
 			m_state = new List<List<int>>();
 			m_copy = new List<List<int>>();
-            m_originalState = new List<List<int>>();
-            m_colors = new Dictionary<int, Color>();
+			m_originalState = new List<List<int>>();
+			m_colors = new Dictionary<int, Color>();
 			m_nCells = nCells;
 			m_nStickers = nStickers;
 			InitializeState();
@@ -94,20 +94,20 @@
 			m_copy[cell][sticker] = color;
 		}
 
-        public void ToggleStickerColorIndex(int cell, int sticker)
-        {
-            var beforeColor = m_copy[cell][sticker];
-            if (beforeColor == m_offColorIndex)
-            {
-                m_copy[cell][sticker] = m_originalState[cell][sticker];
-            }
-            else
-            {
-                m_copy[cell][sticker] = m_offColorIndex;
-            }
-        }
+		public void ToggleStickerColorIndex(int cell, int sticker)
+		{
+			var beforeColor = m_copy[cell][sticker];
+			if (beforeColor == m_offColorIndex)
+			{
+				m_copy[cell][sticker] = m_originalState[cell][sticker];
+			}
+			else
+			{
+				m_copy[cell][sticker] = m_offColorIndex;
+			}
+		}
 
-        public void CommitChanges()
+		public void CommitChanges()
 		{
 			for( int c = 0; c < m_nCells; c++ )
 			for( int s = 0; s < m_nStickers; s++ )
@@ -156,20 +156,20 @@
 		{
 			m_state.Clear();
 			m_copy.Clear();
-            m_originalState.Clear();
+			m_originalState.Clear();
 
-            for ( int c = 0; c < m_nCells; c++ )
+			for ( int c = 0; c < m_nCells; c++ )
 			{
 				m_state.Add( new List<int>() );
 				m_copy.Add( new List<int>() );
-                m_originalState.Add(new List<int>());
+				m_originalState.Add(new List<int>());
 
-                for ( int s = 0; s < m_nStickers; s++ )
+				for ( int s = 0; s < m_nStickers; s++ )
 				{
 					m_state[c].Add( c );
 					m_copy[c].Add( c );
-                    m_originalState[c].Add(c);
-                }
+					m_originalState[c].Add(c);
+				}
 			}
 		}
 
@@ -179,14 +179,14 @@
 		// The matrix integers represent the sticker colors.
 		private List<List<int>> m_state;
 		private List<List<int>> m_copy;
-        private List<List<int>> m_originalState;
+		private List<List<int>> m_originalState;
 
-        /// <summary>
-        /// Called to update our colors.
-        /// </summary>
-        public void UpdateColors( Settings settings )
-        {
-            m_colors[m_offColorIndex] = settings.ColorOff;
+		/// <summary>
+		/// Called to update our colors.
+		/// </summary>
+		public void UpdateColors( Settings settings )
+		{
+			m_colors[m_offColorIndex] = settings.ColorOff;
 			int face = 0;
 			m_colors[face++] = settings.Color1;
 			m_colors[face++] = settings.Color2;
@@ -246,6 +246,6 @@
 			m_colors[face++] = settings.Color56;
 		}
 		private Dictionary<int, Color> m_colors;
-	    private int m_offColorIndex = -1;
+		private int m_offColorIndex = -1;
 	}
 }

--- a/MagicTile/Puzzle/State.cs
+++ b/MagicTile/Puzzle/State.cs
@@ -107,6 +107,23 @@
 			}
 		}
 
+		public bool IsAllOn
+		{
+			get
+			{
+				for (int c = 0; c < m_nCells; c++)
+				{
+					for (int s = 0; s < m_nStickers; s++)
+					{
+						if ( m_state[c][s] != m_originalState[c][s])
+							return false;
+					}
+				}
+
+				return true;
+			}
+		}
+
 		public void CommitChanges()
 		{
 			for( int c = 0; c < m_nCells; c++ )

--- a/MagicTile/Puzzle/State.cs
+++ b/MagicTile/Puzzle/State.cs
@@ -115,7 +115,7 @@
 				{
 					for (int s = 0; s < m_nStickers; s++)
 					{
-						if ( m_state[c][s] != m_originalState[c][s])
+						if (m_state[c][s] != m_originalState[c][s])
 							return false;
 					}
 				}
@@ -175,13 +175,13 @@
 			m_copy.Clear();
 			m_originalState.Clear();
 
-			for ( int c = 0; c < m_nCells; c++ )
+			for( int c = 0; c < m_nCells; c++ )
 			{
 				m_state.Add( new List<int>() );
 				m_copy.Add( new List<int>() );
 				m_originalState.Add(new List<int>());
 
-				for ( int s = 0; s < m_nStickers; s++ )
+				for( int s = 0; s < m_nStickers; s++ )
 				{
 					m_state[c].Add( c );
 					m_copy[c].Add( c );

--- a/MagicTile/Puzzle/State.cs
+++ b/MagicTile/Puzzle/State.cs
@@ -12,7 +12,8 @@
 		{
 			m_state = new List<List<int>>();
 			m_copy = new List<List<int>>();
-			m_colors = new Dictionary<int, Color>();
+            m_originalState = new List<List<int>>();
+            m_colors = new Dictionary<int, Color>();
 			m_nCells = nCells;
 			m_nStickers = nStickers;
 			InitializeState();
@@ -92,7 +93,21 @@
 		{
 			m_copy[cell][sticker] = color;
 		}
-		public void CommitChanges()
+
+        public void ToggleStickerColorIndex(int cell, int sticker)
+        {
+            var beforeColor = m_copy[cell][sticker];
+            if (beforeColor == m_offColorIndex)
+            {
+                m_copy[cell][sticker] = m_originalState[cell][sticker];
+            }
+            else
+            {
+                m_copy[cell][sticker] = m_offColorIndex;
+            }
+        }
+
+        public void CommitChanges()
 		{
 			for( int c = 0; c < m_nCells; c++ )
 			for( int s = 0; s < m_nStickers; s++ )
@@ -141,16 +156,20 @@
 		{
 			m_state.Clear();
 			m_copy.Clear();
+            m_originalState.Clear();
 
-			for( int c = 0; c < m_nCells; c++ )
+            for ( int c = 0; c < m_nCells; c++ )
 			{
 				m_state.Add( new List<int>() );
 				m_copy.Add( new List<int>() );
-				for( int s = 0; s < m_nStickers; s++ )
+                m_originalState.Add(new List<int>());
+
+                for ( int s = 0; s < m_nStickers; s++ )
 				{
 					m_state[c].Add( c );
 					m_copy[c].Add( c );
-				}
+                    m_originalState[c].Add(c);
+                }
 			}
 		}
 
@@ -160,12 +179,14 @@
 		// The matrix integers represent the sticker colors.
 		private List<List<int>> m_state;
 		private List<List<int>> m_copy;
+        private List<List<int>> m_originalState;
 
-		/// <summary>
-		/// Called to update our colors.
-		/// </summary>
-		public void UpdateColors( Settings settings )
-		{
+        /// <summary>
+        /// Called to update our colors.
+        /// </summary>
+        public void UpdateColors( Settings settings )
+        {
+            m_colors[m_offColorIndex] = settings.ColorOff;
 			int face = 0;
 			m_colors[face++] = settings.Color1;
 			m_colors[face++] = settings.Color2;
@@ -225,5 +246,6 @@
 			m_colors[face++] = settings.Color56;
 		}
 		private Dictionary<int, Color> m_colors;
+	    private int m_offColorIndex = -1;
 	}
 }

--- a/MagicTile/Puzzle/Twisting/TwistHandler.cs
+++ b/MagicTile/Puzzle/Twisting/TwistHandler.cs
@@ -228,7 +228,10 @@
 			Cell closestMaster = cell.MasterOrSelf;
 			foreach (Cell neighbor in closestMaster.Neighbors)
 			{
-				m_puzzle.State.ToggleStickerColorIndex(neighbor.IndexOfMaster, 0);
+				if (neighbor != closestMaster || m_puzzle.Config.TogglingMode == TogglingMode.NeighborsAndSelf)
+				{
+					m_puzzle.State.ToggleStickerColorIndex(neighbor.IndexOfMaster, 0);
+				}
 			}
 			m_puzzle.State.CommitChanges();
 			m_twistHistory.Update(closestMaster);
@@ -370,7 +373,7 @@
 		/// <param name="numTwists"></param>
 		public void Scramble( int numTwists )
 		{
-			if (m_puzzle.Config.TogglingMode)
+			if (m_puzzle.Config.TogglingMode != TogglingMode.None)
 			{
 				RandomToggles(numTwists);
 				return;

--- a/MagicTile/Puzzle/Twisting/TwistHandler.cs
+++ b/MagicTile/Puzzle/Twisting/TwistHandler.cs
@@ -223,6 +223,17 @@
 				m_status();
 		}
 
+		public void Toggle(Cell cell)
+		{
+			Cell closestMaster = cell.MasterOrSelf;
+			foreach (Cell neighbor in closestMaster.Neighbors)
+			{
+				m_puzzle.State.ToggleStickerColorIndex(neighbor.IndexOfMaster, 0);
+			}
+			m_puzzle.State.CommitChanges();
+			m_twistHistory.Update(closestMaster);
+		}
+
 		private void BeepIfSolved()
 		{
 			// ZZZ - can beep too much.
@@ -333,12 +344,32 @@
 		}
 		static int count = 0;
 
+		private void RandomToggles(int numTwists)
+		{
+			System.Random rand = new System.Random();
+			var allMasterCells = m_puzzle.MasterCells;
+			for (int i = 0; i < numTwists; i++)
+			{
+				var cell = allMasterCells[rand.Next(allMasterCells.Count)];
+				Toggle(cell);
+			}
+
+			m_twistHistory.Scrambles += numTwists;
+
+			InvalidateAllAndUpdateStatus();
+		}
+
 		/// <summary>
 		/// Scramble.
 		/// </summary>
 		/// <param name="numTwists"></param>
 		public void Scramble( int numTwists )
 		{
+			if (m_puzzle.Config.TogglingMode)
+			{
+				RandomToggles(numTwists);
+				return;
+			}
 			System.Random rand = new System.Random();
 			List<IdentifiedTwistData> allTwistData = m_puzzle.AllTwistData;
 			if( allTwistData.Count == 0 )

--- a/MagicTile/Puzzle/Twisting/TwistHandler.cs
+++ b/MagicTile/Puzzle/Twisting/TwistHandler.cs
@@ -232,6 +232,8 @@
 			}
 			m_puzzle.State.CommitChanges();
 			m_twistHistory.Update(closestMaster);
+			if (!m_twistHistory.Undoing && m_twistHistory.Scrambled && m_puzzle.State.IsAllOn)
+				System.Media.SystemSounds.Asterisk.Play();
 		}
 
 		private void BeepIfSolved()

--- a/MagicTile/Puzzle/Twisting/TwistHandler.cs
+++ b/MagicTile/Puzzle/Twisting/TwistHandler.cs
@@ -237,15 +237,14 @@
 			m_twistHistory.Update(closestMaster);
 			if (updateStatus)
 				m_status();
-
-			if (beep && !m_twistHistory.Undoing && m_twistHistory.Scrambled && m_puzzle.State.IsAllOn)
-				System.Media.SystemSounds.Asterisk.Play();
+			if (beep)
+				BeepIfSolved();
 		}
 
 		private void BeepIfSolved()
 		{
 			// ZZZ - can beep too much.
-			if( !m_twistHistory.Undoing && m_twistHistory.Scrambled && m_puzzle.State.IsSolved )
+			if( !m_twistHistory.Undoing && m_twistHistory.Scrambled && m_puzzle.IsSolved )
 				System.Media.SystemSounds.Asterisk.Play();
 		}
 
@@ -373,7 +372,7 @@
 		/// <param name="numTwists"></param>
 		public void Scramble( int numTwists )
 		{
-			if (m_puzzle.Config.TogglingMode != TogglingMode.None)
+			if (m_puzzle.Config.IsToggling)
 			{
 				RandomToggles(numTwists);
 				return;

--- a/MagicTile/Puzzle/Twisting/TwistHandler.cs
+++ b/MagicTile/Puzzle/Twisting/TwistHandler.cs
@@ -223,7 +223,7 @@
 				m_status();
 		}
 
-		public void Toggle(Cell cell)
+		public void Toggle(Cell cell, bool updateStatus = true, bool beep = true)
 		{
 			Cell closestMaster = cell.MasterOrSelf;
 			foreach (Cell neighbor in closestMaster.Neighbors)
@@ -232,7 +232,10 @@
 			}
 			m_puzzle.State.CommitChanges();
 			m_twistHistory.Update(closestMaster);
-			if (!m_twistHistory.Undoing && m_twistHistory.Scrambled && m_puzzle.State.IsAllOn)
+			if (updateStatus)
+				m_status();
+
+			if (beep && !m_twistHistory.Undoing && m_twistHistory.Scrambled && m_puzzle.State.IsAllOn)
 				System.Media.SystemSounds.Asterisk.Play();
 		}
 
@@ -353,7 +356,7 @@
 			for (int i = 0; i < numTwists; i++)
 			{
 				var cell = allMasterCells[rand.Next(allMasterCells.Count)];
-				Toggle(cell);
+				Toggle(cell, updateStatus: false, beep: false);
 			}
 
 			m_twistHistory.Scrambles += numTwists;

--- a/MagicTile/Puzzle/Twisting/TwistHistory.cs
+++ b/MagicTile/Puzzle/Twisting/TwistHistory.cs
@@ -11,12 +11,14 @@
 
 			m_twists = new TwistList();
 			m_redoTwists = new TwistList();
+			m_toggles = new List<Cell>();
 		}
 
 		public void Clear()
 		{
 			m_twists.Clear();
 			m_redoTwists.Clear();
+			m_toggles.Clear();
 			this.Scrambles = 0;
 		}
 
@@ -96,6 +98,12 @@
 			m_twists.Add( twist );
 		}
 
+		public void Update(Cell toggleCell)
+		{
+			m_toggles.Add( toggleCell );
+		}
+
+
 		/// <summary>
 		/// Get undo rotation parameters.
 		/// Calling this will set us in the "undo" state for the next rotation.
@@ -141,11 +149,16 @@
 			get { return m_twists; }
 		}
 
+		public List<Cell> AllToggles => m_toggles;
+
+		public int AllMovesCount => AllTwists.Count + AllToggles.Count;
+
 		// Whether we are in undo/redo modes.
 		private bool m_undoMode, m_redoMode;
 
 		// Our twist history.
 		private TwistList m_twists;
 		private TwistList m_redoTwists;
+		private List<Cell> m_toggles;
 	}
 }

--- a/MagicTile/Puzzle/Twisting/TwistHistory.cs
+++ b/MagicTile/Puzzle/Twisting/TwistHistory.cs
@@ -98,11 +98,14 @@
 			m_twists.Add( twist );
 		}
 
+		/// <summary>
+		/// Add a toggling move to history
+		/// </summary>
+		/// <param name="toggleCell"></param>
 		public void Update(Cell toggleCell)
 		{
 			m_toggles.Add( toggleCell );
 		}
-
 
 		/// <summary>
 		/// Get undo rotation parameters.

--- a/MagicTile/Settings/Settings.cs
+++ b/MagicTile/Settings/Settings.cs
@@ -312,7 +312,7 @@
 			this.FocalLength = 1;
 			this.ColorBg = Color.DarkGray;
 			this.ColorTileEdges = Color.Black;
-			this.ColorOff = Color.FromArgb(30, 30, 30);
+			this.ColorOff = Color.FromArgb(25, 25, 25);
 		}
 
 		[DataMember]
@@ -624,7 +624,7 @@
 			ColorTwistingCircles = Color.OrangeRed;
 			ColorBg = Color.DarkGray;
 			ColorTileEdges = Color.Black;
-			ColorOff = Color.FromArgb(30, 30, 30);
+			ColorOff = Color.FromArgb(25, 25, 25);
 			Color1 = Color.White;
 			Color2 = Color.Green;
 			Color3 = Color.Blue;

--- a/MagicTile/Settings/Settings.cs
+++ b/MagicTile/Settings/Settings.cs
@@ -312,7 +312,7 @@
 			this.FocalLength = 1;
 			this.ColorBg = Color.DarkGray;
 			this.ColorTileEdges = Color.Black;
-		    this.ColorOff = Color.Black;
+			this.ColorOff = Color.Black;
 		}
 
 		[DataMember]
@@ -333,13 +333,13 @@
 		[Category( "Coloring" )]
 		public Color ColorTileEdges { get; set; }
 
-        [DataMember]
-        [DisplayName("Off Color")]
-        [Description("The color of tile when it is turned off in lights out mode.")]
-        [Category("Coloring")]
-        public Color ColorOff { get; set; }
+		[DataMember]
+		[DisplayName("Off Color")]
+		[Description("The color of tile when it is turned off in lights out mode.")]
+		[Category("Coloring")]
+		public Color ColorOff { get; set; }
 
-        [DataMember]
+		[DataMember]
 		[DisplayName( "Color 1" )]
 		[Category( "Coloring" )]
 		public Color Color1 { get; set; }
@@ -624,8 +624,8 @@
 			ColorTwistingCircles = Color.OrangeRed;
 			ColorBg = Color.DarkGray;
 			ColorTileEdges = Color.Black;
-            ColorOff = Color.Black;
-            Color1 = Color.White;
+			ColorOff = Color.Black;
+			Color1 = Color.White;
 			Color2 = Color.Green;
 			Color3 = Color.Blue;
 			Color4 = Color.Yellow;

--- a/MagicTile/Settings/Settings.cs
+++ b/MagicTile/Settings/Settings.cs
@@ -312,7 +312,7 @@
 			this.FocalLength = 1;
 			this.ColorBg = Color.DarkGray;
 			this.ColorTileEdges = Color.Black;
-			this.ColorOff = Color.Black;
+			this.ColorOff = Color.FromArgb(50, 50, 50);
 		}
 
 		[DataMember]
@@ -624,7 +624,7 @@
 			ColorTwistingCircles = Color.OrangeRed;
 			ColorBg = Color.DarkGray;
 			ColorTileEdges = Color.Black;
-			ColorOff = Color.Black;
+			ColorOff = Color.FromArgb(50, 50, 50);
 			Color1 = Color.White;
 			Color2 = Color.Green;
 			Color3 = Color.Blue;

--- a/MagicTile/Settings/Settings.cs
+++ b/MagicTile/Settings/Settings.cs
@@ -312,7 +312,7 @@
 			this.FocalLength = 1;
 			this.ColorBg = Color.DarkGray;
 			this.ColorTileEdges = Color.Black;
-			this.ColorOff = Color.FromArgb(50, 50, 50);
+			this.ColorOff = Color.FromArgb(30, 30, 30);
 		}
 
 		[DataMember]
@@ -335,7 +335,7 @@
 
 		[DataMember]
 		[DisplayName("Off Color")]
-		[Description("The color of tile when it is turned off in lights out mode.")]
+		[Description("The color of tile when it is turned off in toggling mode.")]
 		[Category("Coloring")]
 		public Color ColorOff { get; set; }
 
@@ -624,7 +624,7 @@
 			ColorTwistingCircles = Color.OrangeRed;
 			ColorBg = Color.DarkGray;
 			ColorTileEdges = Color.Black;
-			ColorOff = Color.FromArgb(50, 50, 50);
+			ColorOff = Color.FromArgb(30, 30, 30);
 			Color1 = Color.White;
 			Color2 = Color.Green;
 			Color3 = Color.Blue;

--- a/MagicTile/Settings/Settings.cs
+++ b/MagicTile/Settings/Settings.cs
@@ -312,6 +312,7 @@
 			this.FocalLength = 1;
 			this.ColorBg = Color.DarkGray;
 			this.ColorTileEdges = Color.Black;
+		    this.ColorOff = Color.Black;
 		}
 
 		[DataMember]
@@ -332,7 +333,13 @@
 		[Category( "Coloring" )]
 		public Color ColorTileEdges { get; set; }
 
-		[DataMember]
+        [DataMember]
+        [DisplayName("Off Color")]
+        [Description("The color of tile when it is turned off in lights out mode.")]
+        [Category("Coloring")]
+        public Color ColorOff { get; set; }
+
+        [DataMember]
 		[DisplayName( "Color 1" )]
 		[Category( "Coloring" )]
 		public Color Color1 { get; set; }
@@ -617,7 +624,8 @@
 			ColorTwistingCircles = Color.OrangeRed;
 			ColorBg = Color.DarkGray;
 			ColorTileEdges = Color.Black;
-			Color1 = Color.White;
+            ColorOff = Color.Black;
+            Color1 = Color.White;
 			Color2 = Color.Green;
 			Color3 = Color.Blue;
 			Color4 = Color.Yellow;

--- a/MagicTile/Utils/MenuBuilder.cs
+++ b/MagicTile/Utils/MenuBuilder.cs
@@ -229,8 +229,8 @@
 			level++;
 
 			PuzzleConfig[] tilings;
-			PuzzleConfig[] face, edge, vertex, mixed, earthquake;
-			puzzleConfigClass.GetPuzzles( out tilings, out face, out edge, out vertex, out mixed, out earthquake );
+			PuzzleConfig[] face, edge, vertex, mixed, earthquake, toggles;
+			puzzleConfigClass.GetPuzzles( out tilings, out face, out edge, out vertex, out mixed, out earthquake, out toggles );
 
 			AddPuzzle( tilings[0], parentTreeNode, parentMenuItem, isTiling: true );
 			AddPuzzle( tilings[1], parentTreeNode, parentMenuItem, isTiling: true );
@@ -305,6 +305,20 @@
 					WriteTableEntry( swWiki, config.MenuName );
 				}
 				EndTable( swWiki );
+			}
+
+			if (toggles.Length > 0)
+			{
+				AddGroup(swWiki, level, "Lights On", parentTreeNode, parentMenuItem, out groupNode, out groupMenuItem);
+				StartTable(swWiki);
+				foreach (PuzzleConfig config in toggles)
+				{
+					if (swList != null)
+						swList.WriteLine(config.DisplayName);
+					AddPuzzle(config, groupNode, groupMenuItem, isTiling: true);
+					WriteTableEntry(swWiki, config.MenuName);
+				}
+				EndTable(swWiki);
 			}
 		}
 


### PR DESCRIPTION
The following things should work:
- Two lights on puzzles for each tiling: toggling neighbors only and toggling neighbors and the clicked tile
- Scramble
- Solved state detection

What's not included:
- Undo and redo
- Macro
- support for skew puzzles in skew views (if users turn off "show as skew", it'll work).