### PR TITLE
Fix puzzle counting for lights-on puzzles

### DIFF
--- a/MagicTile/Puzzle/PuzzleConfigClass.cs
+++ b/MagicTile/Puzzle/PuzzleConfigClass.cs
@@ -226,6 +226,7 @@
 				toggles[i].MenuName = (i == 0 ? "Toggling Neighbors" : "Toggling Clicked Tile And Neighbors");
 				toggles[i].TogglingMode = (i == 0 ? TogglingMode.NeighborsOnly : TogglingMode.NeighborsAndSelf);
 				toggles[i].DisplayName = ClassDisplayName + " " + toggles[i].MenuName;
+				toggles[i].ID = ClassID + toggles[i].MenuName;
 			}
 
 			List<PuzzleConfig> puzzles = new List<PuzzleConfig>();

--- a/MagicTile/Utils/MenuBuilder.cs
+++ b/MagicTile/Utils/MenuBuilder.cs
@@ -315,7 +315,7 @@
 				{
 					if (swList != null)
 						swList.WriteLine(config.DisplayName);
-					AddPuzzle(config, groupNode, groupMenuItem, isTiling: true);
+					AddPuzzle(config, groupNode, groupMenuItem, isTiling: false);
 					WriteTableEntry(swWiki, config.MenuName);
 				}
 				EndTable(swWiki);
@@ -344,7 +344,6 @@
 				if( config.CoxeterComplex )
 				{
 					NumTilings++;
-					NumPuzzles += 2;	// This accounts for lights-on puzzles.
 				}
 			}
 			else


### PR DESCRIPTION
Actually not sure about the style of puzzle ID. I used the display name as part of the ID.

I changed isTiling to true for AddPuzzle. I didn't find any consequence except for puzzle tracking. Feel free to fix it if there are bad side effects.